### PR TITLE
Feature: Add support for registering custom inline editors in Svelte Grid

### DIFF
--- a/svelte/src/components/inlineEditors/Editor.svelte
+++ b/svelte/src/components/inlineEditors/Editor.svelte
@@ -50,7 +50,12 @@
 
 	const SvelteComponent = $derived.by(() => {
 		let editor = column.editor;
+
 		if (typeof editor === "function") editor = editor(row, column);
+
+		if (typeof editor === "object" && !!editor?.component)
+			return editor.component;
+
 		let type = typeof editor === "string" ? editor : editor.type;
 		return editors[type];
 	});

--- a/svelte/src/components/inlineEditors/editors.js
+++ b/svelte/src/components/inlineEditors/editors.js
@@ -9,3 +9,7 @@ export const editors = {
 	datepicker: Datepicker,
 	richselect: Richselect,
 };
+
+export function registerEditor(type, component) {
+	editors[type] = component;
+}

--- a/svelte/src/index.js
+++ b/svelte/src/index.js
@@ -14,6 +14,8 @@ export {
 	defaultToolbarButtons,
 } from "@svar-ui/grid-store";
 
+export { registerEditor } from "./components/inlineEditors/editors";
+
 import { setEnv } from "@svar-ui/lib-dom";
 import { env } from "@svar-ui/lib-svelte";
 setEnv(env);


### PR DESCRIPTION
# Add support for registering custom inline editors in Svelte Grid

## Problem

Currently, the grid only supports a fixed set of inline editors (Text,Combo, Datepicker, Richselect).
It is not possible to register custom editors globally, and using the current examples only produces a visual cell without leveraging the built-in mechanisms for autofocus, interception, and value handling.

## Solution

This PR introduces a registerEditor function and extends the editor resolution logic to support:

### 1. Global registration of custom editors
```
    import { registerEditor } from "@svar-ui/svelte-grid";
    registerEditor("time", TimeEditor); //where TimeEditor is the name of your custom Editor
```

Then use it in column definitions just like built-in editors:
```
    { 
        "id": "time_column_1", 
        "header": "Time Column", 
        "sort": false,  
        "width": 60,
        "editor": "time"
    }
```

### 2. Direct use of custom editor components per column
```
    { 
        "id": "out1", 
        "header": "Out Column", 
        "sort": false,  
        "width": 60,
        "editor": { "component": TimeEditor }
    }
```

Or via a resolver function:
```
    function editorHandler(config) {  
        return (row, col) => {  
            if (col.id.startsWith('in') || col.id.startsWith('out')) {  
                return { component: TimeEditor };  
            }  
            // other logic...  
        }  
    }
```

## Benefits

-   Allows project-wide reuse of custom editors.
-   Keeps existing editor mechanisms (autofocus, intercept, updateValue) intact.
-   Simplifies adding custom data types without rewriting cell logic.

## Testing

-   Add a custom editor using registerEditor or column definition.
-   Ensure the editor mounts correctly, autofocus works, and updates propagate as expected.
